### PR TITLE
Drop support for geopandas < 1 and shapely < 2

### DIFF
--- a/demeter/raster/sentinel2/utils/tiles.py
+++ b/demeter/raster/sentinel2/utils/tiles.py
@@ -80,7 +80,7 @@ def find_tiles_for_geometries(
         )
         geometries_projected = geometries_clipped_to_utm_zone.to_crs(
             epsg=int(utm_zone.code)
-        ).unary_union
+        ).union_all()
 
         # Select the minimum number of tiles that cover the input geometries:
         tiles_selected = _select_tiles(tiles_projected, geometries_projected)
@@ -146,7 +146,7 @@ def _select_tiles(
     for tile_count in range(1, len(tiles_intersecting) + 1):
         for tile_ids in combinations(tiles_intersecting.index, tile_count):
             tiles = tiles_intersecting.loc[list(tile_ids)]
-            if tiles.unary_union.covers(geometries_union):
+            if tiles.union_all().covers(geometries_union):
                 return tiles
 
     raise Exception("Could not find tiles that cover the input geometries")

--- a/demeter/raster/usgs/hydrography.py
+++ b/demeter/raster/usgs/hydrography.py
@@ -315,7 +315,7 @@ def find_hu4_codes(
     # regions that intersect with the geometries. This web service errors out
     # if we try to query using a large geo file, so use the bounding box:
     geometries_in_4326 = geometries.to_crs("EPSG:4326")
-    geometries_combined = geometries_in_4326.unary_union
+    geometries_combined = geometries_in_4326.union_all()
     bounding_box = shapely.geometry.box(*geometries_combined.bounds)
     bounding_box_as_ersi_json = {"rings": bounding_box.__geo_interface__["coordinates"]}
     response = requests.get(
@@ -342,7 +342,7 @@ def find_hu4_codes(
         raise ValueError("No HU4 regions found for geometries. Are they in CONUS?")
 
     geometries_without_hu4_region = geometries[
-        geometries_in_4326.disjoint(hu4_regions.unary_union)
+        geometries_in_4326.disjoint(hu4_regions.union_all())
     ]
     if not geometries_without_hu4_region.empty:
         raise ValueError(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,14 +13,13 @@ dependencies = [
   "dbfread",
   "defusedxml",
   "filelock",
-  "geopandas",
+  "geopandas ~= 1.0",
   "numpy",
   "pandas",
   "pyproj",
   "rasterio ~= 1.4.3",
   "requests",
-  "rtree",
-  "shapely",
+  "shapely ~= 2.0",
   "smart-open",
 ]
 
@@ -71,17 +70,12 @@ filterwarnings = [
 [[tool.mypy.overrides]]
 module = [
   "dbfread.*",
+  "geopandas.*",
   "rasterio.*",
   "shapely.*",
   "smart_open.*",
 ]
 follow_untyped_imports = true
-
-[[tool.mypy.overrides]]
-module = [
-  "geopandas.*",
-]
-ignore_missing_imports = true
 
 [[tool.pydoc-markdown.loaders]]
 type = "python"


### PR DESCRIPTION
Deepnote has removed geopandas and shapely from their constraints file: https://deepnote-compute-dependencies.s3.us-east-1.amazonaws.com/deepnote-toolkit/latest/constraints3.9.txt

This means we can use more recent versions of both libraries, which should resolve our issues with dynamic imports.