### PR TITLE
Support SAFE filenames from new Sentinel-2C satellite

### DIFF
--- a/demeter/raster/sentinel2/utils/rasters.py
+++ b/demeter/raster/sentinel2/utils/rasters.py
@@ -11,7 +11,7 @@ from demeter.raster.sentinel2.utils.download import download_keys
 # Example: "S2B_MSIL2A_20240901T172859_N0511_R055_T14TMM_20240901T215725.SAFE"
 SAFE_FILENAME_PATTERN = re.compile(
     r"""\b
-    (?P<mission>S2A|S2B)_                   # S2B
+    (?P<mission>S2[A-Z])_                   # S2B
     (?P<product_level>MSIL2A)_              # MSIL2A
     (?P<datatake_timestamp>\d{8}T\d{6})_    # 20240901T172859
     (?P<processing_baseline>N\d{4})_        # N0511

--- a/tests/raster/sentinel2/utils/test_rasters.py
+++ b/tests/raster/sentinel2/utils/test_rasters.py
@@ -1,0 +1,11 @@
+from demeter.raster.sentinel2.utils.rasters import SafeMetadata
+
+
+def test_safe_metadata():
+    metadata = SafeMetadata.from_filename(
+        "Sentinel-2/MSI/L2A/2024/12/16/S2C_MSIL2A_20241216T184831_N9905_R070_T10SFG_20241216T221754.SAFE"
+    )
+    assert metadata.tile_id == "10SFG"
+    assert metadata.datatake_timestamp == "20241216T184831"
+    assert metadata.utm_zone == "10"
+    assert metadata.crs == "EPSG:32610"


### PR DESCRIPTION
The ESA recently launched a third Sentinel-2 satellite: https://www.copernicus.eu/en/news/news/observer-sentinel-2c-joins-copernicus-family

This means we now have SAFE filenames beginning with `S2C`. This updates the SAFE regex to include these filenames.