### PR TITLE
Merge USGS and Sentinel-2 rasters on disk

### DIFF
--- a/demeter/raster/__init__.py
+++ b/demeter/raster/__init__.py
@@ -82,6 +82,13 @@ class Raster:
         """
         return self.pixels.dtype
 
+    @property
+    def nodata(self):
+        """
+        The raster's nodata value.
+        """
+        return self.pixels.fill_value
+
     def value_at(self, x: float, y: float):
         """
         Find the pixel corresponding to the given coordinates, and return its
@@ -141,7 +148,7 @@ class Raster:
             "count": self.count,
             "crs": self.crs,
             "dtype": self.dtype,
-            "nodata": self.pixels.fill_value,
+            "nodata": self.nodata,
             "transform": self.transform,
         }
 

--- a/demeter/raster/sentinel2/ndvi.py
+++ b/demeter/raster/sentinel2/ndvi.py
@@ -31,7 +31,7 @@ from concurrent.futures import ProcessPoolExecutor
 from dataclasses import dataclass
 from itertools import groupby
 from tempfile import TemporaryDirectory
-from typing import Literal, Optional, Union, cast
+from typing import Literal, Optional, Union, cast, overload
 
 import geopandas
 import numpy
@@ -63,12 +63,48 @@ def _ndvi_band(value: str) -> Band:
 
 
 @dataclass
-class NDVIRasters:
+class NDVIRastersBase:
     crs: str
+
+
+@dataclass
+class NDVIRasters(NDVIRastersBase):
     mean: Optional[Raster] = None
     min: Optional[Raster] = None
     max: Optional[Raster] = None
     stddev: Optional[Raster] = None
+
+
+@dataclass
+class NDVIRastersOnDisk(NDVIRastersBase):
+    mean: Optional[str] = None
+    min: Optional[str] = None
+    max: Optional[str] = None
+    stddev: Optional[str] = None
+
+
+@overload
+def fetch_and_build_ndvi_rasters(
+    geometries: Union[str, geopandas.GeoDataFrame, geopandas.GeoSeries],
+    year: int,
+    month: int,
+    statistics: Optional[Collection[Literal["mean", "min", "max", "stddev"]]] = None,
+    *,
+    crop: bool = True,
+    dst_path: str,
+) -> Iterable[NDVIRastersOnDisk]: ...
+
+
+@overload
+def fetch_and_build_ndvi_rasters(
+    geometries: Union[str, geopandas.GeoDataFrame, geopandas.GeoSeries],
+    year: int,
+    month: int,
+    statistics: Optional[Collection[Literal["mean", "min", "max", "stddev"]]] = None,
+    *,
+    crop: bool = True,
+    dst_path: None = None,
+) -> Iterable[NDVIRasters]: ...
 
 
 def fetch_and_build_ndvi_rasters(
@@ -76,8 +112,10 @@ def fetch_and_build_ndvi_rasters(
     year: int,
     month: int,
     statistics: Optional[Collection[Literal["mean", "min", "max", "stddev"]]] = None,
+    *,
     crop: bool = True,
-) -> Iterable[NDVIRasters]:
+    dst_path: Optional[str] = None,
+) -> Iterable[Union[NDVIRasters, NDVIRastersOnDisk]]:
     """
     Download red and NIR reflectance rasters from Sentinel-2 for the given
     geometries over the given month, use them to calculate NDVI, and merge the
@@ -86,6 +124,9 @@ def fetch_and_build_ndvi_rasters(
     If `crop` is True (the default), crop the output raster to the given
     geometries. If `crop` if False, the output raster will cover the extent of
     the Sentinel-2 rasters intersecting with the given geometries.
+
+    If `dst_path` is given, NDVI rasters will be saved to that directory. Use
+    this for large geometries that don't fit in memory.
     """
     if isinstance(geometries, str):
         geometries = geopandas.read_file(geometries)
@@ -107,7 +148,10 @@ def fetch_and_build_ndvi_rasters(
         ],
     )
     return fetch_and_build_ndvi_rasters_from_keys(
-        raster_keys, statistics, crop_to=geometries if crop else None
+        raster_keys,
+        statistics,
+        crop_to=geometries if crop else None,
+        dst_path=dst_path,
     )
 
 
@@ -115,7 +159,8 @@ def fetch_and_build_ndvi_rasters_from_keys(
     raster_keys: Iterable[str],
     statistics: Optional[Collection[Literal["mean", "min", "max", "stddev"]]] = None,
     crop_to: Optional[Union[geopandas.GeoDataFrame, geopandas.GeoSeries]] = None,
-) -> Iterable[NDVIRasters]:
+    dst_path: Optional[str] = None,
+) -> Iterable[Union[NDVIRasters, NDVIRastersOnDisk]]:
     """
     Download the given rasters, use them to calculate NDVI, and merge the NDVI
     rasters together per the requested statistics.
@@ -145,7 +190,9 @@ def fetch_and_build_ndvi_rasters_from_keys(
     for crs, raster_paths in groupby(
         download_paths, lambda path: SafeMetadata.from_filename(path).crs
     ):
-        yield build_ndvi_rasters_for_crs(crs, raster_paths, statistics, crop_to)
+        yield build_ndvi_rasters_for_crs(
+            crs, raster_paths, statistics, crop_to, dst_path
+        )
 
 
 def build_ndvi_rasters_for_crs(
@@ -153,7 +200,8 @@ def build_ndvi_rasters_for_crs(
     raster_paths: Iterable[str],
     statistics: Optional[Collection[Literal["mean", "min", "max", "stddev"]]] = None,
     crop_to: Optional[Union[geopandas.GeoDataFrame, geopandas.GeoSeries]] = None,
-) -> NDVIRasters:
+    dst_path: Optional[str] = None,
+) -> Union[NDVIRasters, NDVIRastersOnDisk]:
     """
     Build NDVI rasters for each datatake, then merge them together according to
     the requested statistic.
@@ -175,7 +223,15 @@ def build_ndvi_rasters_for_crs(
 
     print(f"Building {statistics} NDVI rasters for {crs}")
 
-    rasters = NDVIRasters(crs=crs)
+    if dst_path is None:
+        rasters: Union[NDVIRasters, NDVIRastersOnDisk] = NDVIRasters(crs=crs)
+    else:
+        try:
+            os.mkdir(dst_path)
+        except FileExistsError:
+            pass
+        os.mkdir(os.path.join(dst_path, crs))
+        rasters = NDVIRastersOnDisk(crs=crs)
 
     if crop_to is None:
         crop_to_projected = None
@@ -218,18 +274,27 @@ def build_ndvi_rasters_for_crs(
         for statistic in statistics:
             print(f"Calculating {statistic} NDVI raster in {crs}")
             merged_ndvi_raster = merge(
-                ndvi_raster_paths, method=statistic, allow_resampling=False
+                ndvi_raster_paths,
+                method=statistic,
+                allow_resampling=False,
+                dst_path=(
+                    os.path.join(dst_path, crs, f"{statistic}.tif")
+                    if dst_path
+                    else None
+                ),
             )
-            assert merged_ndvi_raster.crs == crs
             setattr(rasters, statistic, merged_ndvi_raster)
 
         if calculate_stddev:
             print(f"Calculating standard deviation NDVI raster in {crs}")
             assert rasters.mean
             stddev_ndvi_raster = merge_stddev(
-                ndvi_raster_paths, rasters.mean, allow_resampling=False
+                ndvi_raster_paths,
+                rasters.mean,
+                dst_path=(
+                    os.path.join(dst_path, crs, "stddev.tif") if dst_path else None
+                ),
             )
-            assert stddev_ndvi_raster.crs == crs
             rasters.stddev = stddev_ndvi_raster
 
     return rasters

--- a/demeter/raster/utils/mask.py
+++ b/demeter/raster/utils/mask.py
@@ -1,18 +1,52 @@
 from contextlib import nullcontext
+from typing import Optional, Union, overload
 
 import geopandas
 import rasterio
+import rasterio.features
 import rasterio.mask
+import rasterio.windows
 
 from demeter.raster import Raster
 
 
-def mask(raster, shapes, **kwargs) -> Raster:
+@overload
+def mask(
+    raster,
+    shapes,
+    *,
+    crop: bool = False,
+    dst_path: str,
+    **kwargs,
+) -> str: ...
+
+
+@overload
+def mask(
+    raster,
+    shapes,
+    *,
+    crop: bool = False,
+    dst_path: None = None,
+    **kwargs,
+) -> Raster: ...
+
+
+def mask(
+    raster,
+    shapes,
+    *,
+    crop: bool = False,
+    dst_path: Optional[str] = None,
+    **kwargs,
+) -> Union[str, Raster]:
     """
     Wraps `rasterio.mask.mask`, with the following differences:
 
     - Can accept a `Raster` instance as well as a rasterio dataset.
     - Returns a `Raster` instance instead of a (raster, transform) 2-tuple.
+    - Alternatively, writes the masked raster to disk if `dst_path` is given.
+      Useful for large rasters that don't fit in memory.
     """
     if isinstance(shapes, geopandas.GeoDataFrame):
         shapes = shapes.geometry
@@ -24,11 +58,40 @@ def mask(raster, shapes, **kwargs) -> Raster:
     else:
         dataset_opener = nullcontext
 
-    with dataset_opener(raster) as dataset:
-        crs = dataset.crs
+    with dataset_opener(raster) as src:
+        crs = src.crs
         if crs is None:
             raise ValueError("Raster has no CRS")
 
-        pixels, transform = rasterio.mask.mask(dataset, shapes, filled=False, **kwargs)
+        if dst_path is None:
+            pixels, transform = rasterio.mask.mask(
+                src, shapes, filled=False, crop=crop, **kwargs
+            )
+            return Raster(pixels, transform, str(crs))
 
-    return Raster(pixels, transform, str(crs))
+        # If `dst_path` is given, write the masked raster to disk in chunks:
+        profile = src.profile
+        if crop:
+            # TODO: padding
+            window = rasterio.features.geometry_window(src, shapes)
+            profile.update(
+                width=window.width,
+                height=window.height,
+                transform=src.window_transform(window),
+            )
+        else:
+            window = rasterio.windows.Window(0, 0, src.width, src.height)
+
+        chunks = rasterio.windows.subdivide(
+            window, 512, 512  # TODO: parametrize chunk size?
+        )
+
+        with rasterio.open(dst_path, "w", **profile) as dst:
+            for chunk in chunks:
+                pixels = src.read(window=chunk, masked=True)
+                transform = src.window_transform(chunk)
+                raster = Raster(pixels, transform, str(crs))
+                masked = mask(raster, shapes, crop=False, **kwargs)
+                dst.write(masked.pixels, window=chunk)
+
+        return dst_path

--- a/demeter/raster/utils/merge.py
+++ b/demeter/raster/utils/merge.py
@@ -1,13 +1,16 @@
 import os
+import shutil
 import warnings
 from collections.abc import Callable, Iterable, Sequence
 from contextlib import ExitStack, contextmanager, nullcontext
-from typing import Literal, Optional, Union
+from tempfile import TemporaryDirectory
+from typing import Literal, Optional, Union, overload
 
 import numpy
 import rasterio
 import rasterio.merge
-from rasterio.merge import copy_count, copy_sum
+import rasterio.stack
+from rasterio.merge import copy_count, copy_first, copy_sum
 
 from demeter.raster import Raster
 from demeter.raster.utils.transform import (
@@ -16,6 +19,7 @@ from demeter.raster.utils.transform import (
 )
 
 
+@overload
 def merge(
     rasters: Sequence,
     *,
@@ -24,8 +28,36 @@ def merge(
     ] = "first",
     bounds: Optional[tuple[float, float, float, float]] = None,
     allow_resampling: bool = True,
+    dst_path: str,
     **kwargs,
-) -> Raster:
+) -> str: ...
+
+
+@overload
+def merge(
+    rasters: Sequence,
+    *,
+    method: Union[
+        Literal["first", "last", "min", "max", "sum", "count", "mean"], Callable
+    ] = "first",
+    bounds: Optional[tuple[float, float, float, float]] = None,
+    allow_resampling: bool = True,
+    dst_path: None = None,
+    **kwargs,
+) -> Raster: ...
+
+
+def merge(
+    rasters,
+    *,
+    method: Union[
+        Literal["first", "last", "min", "max", "sum", "count", "mean"], Callable
+    ] = "first",
+    bounds: Optional[tuple[float, float, float, float]] = None,
+    allow_resampling: bool = True,
+    dst_path: Optional[str] = None,
+    **kwargs,
+) -> Union[str, Raster]:
     """
     Wraps `rasterio.merge.merge` to operate on Raster instances as well as
     rasterio datasets.
@@ -44,6 +76,10 @@ def merge(
     By default, this function will resample rasters if they don't align to a
     common pixel grid. To prevent this, set `allow_resampling=False`. This will
     raise an error if the input rasters don't align.
+
+    If you pass `dst_path`, the merged raster will be written to disk and the
+    path to the file will be returned. Use this for large rasters that don't
+    fit in memory.
     """
     if isinstance(rasters[0], Raster):
         dataset_opener = _rasters_as_datasets
@@ -56,32 +92,57 @@ def merge(
             method=method,
             bounds=bounds,
             allow_resampling=allow_resampling,
+            dst_path=dst_path,
             **kwargs,
         )
 
 
-def merge_variance(rasters: Sequence, mean: Raster, **kwargs) -> Raster:
+def merge_variance(
+    rasters: Sequence,
+    mean: Union[str, Raster],
+    dst_path: Optional[str] = None,
+    **kwargs,
+) -> Union[str, Raster]:
     """
     Calculate the mean variance of rasters from the given mean.
     """
-    raster = merge(
-        rasters,
-        method=_copy_variance_sum_and_count(mean.pixels),
-        output_count=2,
-        **kwargs,
-    )
-    return _mean_from_sum_and_count(raster)
+    with TemporaryDirectory() as tmpdir:
+        if isinstance(mean, str) and isinstance(rasters[0], Raster):
+            mean = Raster.from_file(mean)
+        elif isinstance(mean, Raster) and isinstance(rasters[0], str):
+            mean_path = os.path.join(tmpdir, "mean.tif")
+            mean.save(mean_path)
+            mean = mean_path
+
+        # First, stack the input rasters with the mean raster.
+        stacked_path = os.path.join(tmpdir, "stacked.tif")
+        _stack([*rasters, mean], allow_resampling=False, dst_path=stacked_path)
+
+        # Then, merge the stacked raster to calculate variance.
+        return merge(
+            [stacked_path],
+            method=_copy_variance_from_stacked_mean,
+            output_count=1,
+            dst_path=dst_path,
+            **kwargs,
+        )
 
 
-def merge_stddev(rasters: Sequence, mean: Raster, **kwargs) -> Raster:
+def merge_stddev(
+    rasters: Sequence,
+    mean: Union[str, Raster],
+    dst_path: Optional[str] = None,
+    **kwargs,
+) -> Union[str, Raster]:
     """
     Calculate the mean standard deviation of rasters from the given mean.
     """
     variance_raster = merge_variance(rasters, mean, **kwargs)
-    return Raster(
-        numpy.sqrt(variance_raster.pixels),
-        variance_raster.transform,
-        variance_raster.crs,
+    return merge(
+        [variance_raster],
+        method=_ufunc_as_merge_method(numpy.sqrt),
+        dst_path=dst_path,
+        **kwargs,
     )
 
 
@@ -92,6 +153,15 @@ def _rasters_as_datasets(rasters: Iterable[Raster]):
         yield datasets
 
 
+@contextmanager
+def _dataset_opener(source):
+    if isinstance(source, (str, os.PathLike)):
+        with rasterio.open(source) as dataset:
+            yield dataset
+    else:
+        yield source
+
+
 def _merge(
     sources: Sequence,
     *,
@@ -99,20 +169,16 @@ def _merge(
     bounds=None,
     allow_resampling=True,
     output_count=None,
+    dst_path: Optional[str] = None,
     **kwargs,
-) -> Raster:
+) -> Union[str, Raster]:
     # Get the CRS from the first raster. If any of the other rasters have a
     # different CRS, the call to `rasterio.merge.merge` below will raise an
     # exception, so we can safely assume this is the CRS to use for the output
     # raster.
     first_source = sources[0]
 
-    if isinstance(first_source, (str, os.PathLike)):
-        dataset_opener = rasterio.open
-    else:
-        dataset_opener = nullcontext
-
-    with dataset_opener(first_source) as dataset:
+    with _dataset_opener(first_source) as dataset:
         crs = dataset.crs
         num_bands = dataset.count
         transform = dataset.transform
@@ -123,23 +189,10 @@ def _merge(
     # To merge without resampling, all rasters must be on the same pixel grid.
     # Rasterio doesn't provide a way to enforce this when merging, so check
     # first:
-    if not allow_resampling:
-        xs = []
-        ys = []
-        transforms = []
-        for source in sources:
-            with dataset_opener(source) as dataset:
-                transforms.append(dataset.transform)
-                left, bottom, right, top = dataset.bounds
-                xs += [left, right]
-                ys += [bottom, top]
-
-        extent = min(xs), min(ys), max(xs), max(ys)
-
-        if not aligned_pixel_grids(extent, transforms):
-            raise ValueError(
-                "Rasters must be on the same pixel grid to merge without resampling"
-            )
+    if not allow_resampling and not _aligned_pixel_grids(sources):
+        raise ValueError(
+            "Rasters must be on the same pixel grid to merge without resampling"
+        )
 
     # If bounds are given, snap them to the first raster's pixel grid:
     if bounds:
@@ -158,27 +211,56 @@ def _merge(
         method = _copy_sum_and_count
         output_count = 2
 
-    pixels, transform = rasterio.merge.merge(
+    merged = rasterio.merge.merge(
         sources,
         masked=True,
         method=method,
         bounds=bounds,
+        dst_path=dst_path,
         output_count=output_count,
         **kwargs,
     )
-    raster = Raster(pixels, transform, str(crs))
+
+    if dst_path is None:
+        pixels, transform = merged
+        raster: Union[str, Raster] = Raster(pixels, transform, str(crs))
+    else:
+        raster = dst_path
 
     if calculating_mean:
         return _mean_from_sum_and_count(raster)
-
     return raster
 
 
-def _mean_from_sum_and_count(raster: Raster) -> Raster:
+def _mean_from_sum_and_count(raster: Union[str, Raster]) -> Union[str, Raster]:
+    if isinstance(raster, str):
+        with TemporaryDirectory() as tmpdir:
+            tmp_path = os.path.join(tmpdir, "mean.tif")
+            rasterio.merge.merge(
+                [raster],
+                masked=True,
+                method=_copy_mean_from_sum_and_count,
+                dst_path=tmp_path,
+                output_count=1,
+            )
+            shutil.copyfile(tmp_path, raster)
+        return raster
+
     pixels, transform, crs = raster
     pixels_sum, pixels_count = pixels
     pixels_mean = pixels_sum / pixels_count
     return Raster(pixels_mean, transform, crs)
+
+
+def _ufunc_as_merge_method(fn):
+    """
+    Take numpy ufunc, and return a rasterio merge method that applies it.
+    """
+
+    def merge_method(merged_data, new_data, merged_mask, new_mask, **kwargs):
+        copy_first(merged_data, fn(new_data), merged_mask, new_mask, **kwargs)
+
+    return merge_method
 
 
 def _copy_sum_and_count(merged_data, new_data, merged_mask, new_mask, **kwargs):
@@ -190,6 +272,7 @@ def _copy_sum_and_count(merged_data, new_data, merged_mask, new_mask, **kwargs):
     using the first for the sum and the second for the count.
     """
     assert merged_data.ndim == 3 and len(merged_data) == 2
+    assert new_data.ndim == 3 and len(new_data) == 1
     merged_sum, merged_count = numpy.split(merged_data, 2)
     merged_sum_mask, merged_count_mask = numpy.split(merged_mask, 2)
 
@@ -197,17 +280,74 @@ def _copy_sum_and_count(merged_data, new_data, merged_mask, new_mask, **kwargs):
     copy_count(merged_count, new_data, merged_count_mask, new_mask, **kwargs)
 
 
-def _copy_variance_sum_and_count(mean):
-    def _copy(merged_data, new_data, merged_mask, new_mask, **kwargs):
-        assert merged_data.ndim == 3 and len(merged_data) == 2
-        merged_sum, merged_count = numpy.split(merged_data, 2)
-        merged_sum_mask, merged_count_mask = numpy.split(merged_mask, 2)
+def _copy_mean_from_sum_and_count(
+    merged_data, new_data, merged_mask, new_mask, **kwargs
+):
+    """
+    Pass this as the `method` argument to `rasterio.merge.merge` to combine an
+    2-band raster of sum and count values into a 1-band raster of mean values.
 
-        variance = (new_data - mean) ** 2
-        copy_sum(merged_sum, variance, merged_sum_mask, new_mask, **kwargs)
-        copy_count(merged_count, new_data, merged_count_mask, new_mask, **kwargs)
+    Using `rasterio.merge.merge` is a bit of a hack for this, since we're not
+    actually merging 2 rasters together. But it allows us to leverage existing
+    code in rasterio for chunking the data, which is helpful for large rasters
+    that don't fit in memory.
+    """
+    assert merged_data.ndim == 3 and len(merged_data) == 1
+    assert new_data.ndim == 3 and len(new_data) == 2
+    new_sum, new_count = numpy.split(new_data, 2)
+    new_sum_mask, new_count_mask = numpy.split(new_mask, 2)
 
-    return _copy
+    new_mask = numpy.logical_and(new_sum_mask, new_count_mask)
+    mean = new_sum / new_count
+    copy_first(merged_data, mean, merged_mask, new_mask, **kwargs)
+
+
+def _copy_variance_from_stacked_mean(
+    merged_data, new_data, merged_mask, new_mask, **kwargs
+):
+    """
+    Given a multi-band raster where the *last* raster is the mean of all the
+    other bands, calculate and return the variance of all the other bands.
+    """
+    assert merged_data.ndim == 3 and len(merged_data) == 1
+    assert new_data.ndim == 3 and len(new_data) > 1
+    new_values, new_mean = numpy.split(new_data, [-1])
+    _, new_mean_mask = numpy.split(new_mask, [-1])
+
+    variance = (new_values - new_mean) ** 2
+    mean_variance = variance.mean(axis=0, keepdims=True)
+    copy_first(merged_data, mean_variance, merged_mask, new_mean_mask, **kwargs)
+
+
+def _stack(rasters: Sequence, *, allow_resampling=True, **kwargs):
+    if isinstance(rasters[0], Raster):
+        dataset_opener = _rasters_as_datasets
+    else:
+        dataset_opener = nullcontext  # type: ignore
+
+    with dataset_opener(rasters) as sources:
+        if not allow_resampling and not _aligned_pixel_grids(sources):
+            raise ValueError(
+                "Rasters must be on the same pixel grid to stack without resampling"
+            )
+
+        return rasterio.stack.stack(sources, **kwargs)
+
+
+def _aligned_pixel_grids(sources) -> bool:
+    xs = []
+    ys = []
+    transforms = []
+    for source in sources:
+        with _dataset_opener(source) as dataset:
+            transforms.append(dataset.transform)
+            left, bottom, right, top = dataset.bounds
+            xs += [left, right]
+            ys += [bottom, top]
+
+    extent = min(xs), min(ys), max(xs), max(ys)
+
+    return aligned_pixel_grids(extent, transforms)
 
 
 class OverlappingPixelsWarning(Warning):

--- a/demeter/raster/utils/reprojection.py
+++ b/demeter/raster/utils/reprojection.py
@@ -98,7 +98,7 @@ def reproject(
         destination,
         src_crs=raster.crs,
         src_transform=raster.transform,
-        src_nodata=raster.pixels.fill_value,
+        src_nodata=raster.nodata,
         dst_crs=crs,
         dst_transform=dst_transform,
         resampling=rasterio.enums.Resampling[resampling_method],
@@ -107,9 +107,7 @@ def reproject(
 
     # `rasterio.warp.reproject` doesn't return a masked array, even with
     # `masked=True`. See https://github.com/rasterio/rasterio/pull/3289
-    pixels = numpy.ma.masked_equal(
-        pixels, raster.pixels.fill_value.astype(pixels.dtype)
-    )
+    pixels = numpy.ma.masked_equal(pixels, raster.nodata.astype(pixels.dtype))
 
     return Raster(pixels, transform, crs)
 

--- a/tests/raster/usgs/test_topography.py
+++ b/tests/raster/usgs/test_topography.py
@@ -2,6 +2,7 @@ import geopandas
 import pytest
 import rasterio.transform
 
+from demeter.raster import Raster
 from demeter.raster.usgs.topography import RASTER_CRS, fetch_and_merge_rasters
 
 
@@ -17,8 +18,15 @@ def geometries_different_pixel_grid():
 
 
 # TODO: save test fixtures
-def test_fetch_and_merge_rasters(geometries):
-    raster = fetch_and_merge_rasters(geometries)
+@pytest.mark.parametrize("filename", (None, "raster.tif"))
+def test_fetch_and_merge_rasters(geometries, tmp_path, filename):
+    if filename is None:
+        raster = fetch_and_merge_rasters(geometries)
+    else:
+        raster_path = str(tmp_path / filename)
+        fetch_and_merge_rasters(geometries, dst_path=raster_path)
+        raster = Raster.from_file(raster_path)
+
     assert raster.shape == (14934, 4791)
     assert raster.crs == "EPSG:4269"
     assert raster.pixels.count() == 6019


### PR DESCRIPTION
We currently merge rasters in memory. Trying to fetch rasters for large areas causes out of memory errors.

Rasterio's merge function has a `dst_path` argument that allows rasters to be merged and written to disk in chunks. This adds a corresponding `dst_path` argument to the USGS and Sentinel-2 data fetching functions, to allow fetching rasters that are too big to fit in memory.